### PR TITLE
Overhaul the docker image

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -16,6 +16,7 @@
     "Cro::HTTP",
     "Cro::HTTP::Test",
     "Crypt::Bcrypt",
+    "DBIish",
     "Email::Simple",
     "Net::SMTP",
     "Template::Mojo",

--- a/README.md
+++ b/README.md
@@ -1,21 +1,26 @@
 # MyJudo   [![Build Status](https://travis-ci.org/lancew/MyJudo.svg?branch=master)](https://travis-ci.org/lancew/MyJudo) [![Kritika Analysis Status](https://kritika.io/users/lancew/repos/1285814063416590/heads/master/status.svg)](https://kritika.io/users/lancew/repos/1285814063416590/heads/master/)
 
-This is an experimental website using Perl6 programming language and cro.
+This is an experimental website using the Perl 6 programming language and Cro.
 
-Now with DOCKER!
+## Building
 
-Run a built image:
-```
-docker run -p 8080:10000 --mount type=bind,source="/db/myjudo.db",target="/db/myjudo.db" myjudo perl6 -Ilib service.p6
-```
-
-Build an image:
 ```
 docker build -t myjudo .
 ```
 
+## Running
 
----
+```
+docker run -p 80:1080 -p 443:1443 -u "`id -u`:`id -g`" -v $PWD/db:/app/db myjudo
+```
+
+Add resources/fake-tls/ca-crt.pem to your browser to avoid scary self signed
+warnings.
+
+Visit http://localhost and get redirected to https://localhost
+
+## Testing
+
 First install `sqlite3` and make sure by running `sqlite3 --version`
 that the one you have is greater than to `3.8.3`.
 
@@ -25,40 +30,13 @@ Then install needed modules with:
 zef install --deps-only .
 ```
 
-The app uses the /db/myjudo.db and you may need to manually apply the latest schema.
-
-Schema's are being stored in the db directory and you can cut and paste the various
-CREATE TABLE... commands after running sqlite3 db/myjudo.db
-
-For the password reset function to work you will need to add SMTP credentials
-
-And then start the site locally with:
+Finally run the tests with:
 
 ```
-cro run
-```
-
-on production we run it like this:
-
-```
-perl6 -Ilib service.p6
+prove6 -I=lib -v t/*
 ```
 
 ---
-We need to set some environment variables:
-
-```
-export MYJUDO_HOST=0.0.0.0
-export MYJUDO_PORT=443
-export MYJUDO_TLS_KEY=/....../myjudo.net/privkey.pem
-export MYJUDO_TLS_CERT=/...../myjudo.net/fullchain.pem
-```
-
-You can run tests with:
-```
- prove6 -I=lib -v t/*
-
-```
 
 Currently running at https://myjudo.net
 
@@ -66,5 +44,4 @@ This app is serving as basis for my November 2017 workshop at the London Perl Wo
 
 http://act.yapc.eu/lpw2017/talk/7213
 
-
-[Scuttlebutt](https://www.scuttlebutt.nz/)  user?, you can also clone this repo via ssb://%MkBUFeRs7fTN2lAUXuYYaK3i9ln29vBisvJnhEcx4KA=.sha256
+[Scuttlebutt](https://www.scuttlebutt.nz/) user?, you can also clone this repo via ssb://%MkBUFeRs7fTN2lAUXuYYaK3i9ln29vBisvJnhEcx4KA=.sha256

--- a/lib/Routes.pm6
+++ b/lib/Routes.pm6
@@ -17,7 +17,7 @@ class UserSession does Cro::HTTP::Auth {
 }
 
 my $mj = MyJudo.new(
-    dbh => DBIish.connect("SQLite", :database</db/myjudo.db>),
+    dbh => DBIish.connect("SQLite", :database<db/myjudo.db>),
 );
 
 sub routes() is export {


### PR DESCRIPTION
- Simplify the README.md to show how to run it.
- Fold HTTP redirection into the same stack.
- Note the bug around H2 ATM.
- Unbuffer STDERR/OUT so the logs work in realtime.
- Make the docker image MUCH smaller: ~500MiB → <100MiB
- Use the latest Perl 6 release.
- Add the midding dep to the META6.json